### PR TITLE
remove deprecated ciphers

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -91,7 +91,7 @@ ADD ./etc/ssh/magento2docker.pub /root/.ssh/authorized_keys
 RUN chmod -R 700 /root/.ssh
 #END
 
-RUN echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,blowfish-cbc,aes128-cbc,3des-cbc,cast128-cbc,arcfour,aes192-cbc,aes256-cbc" >> /etc/ssh/sshd_config
+RUN echo "Ciphers aes128-ctr,aes192-ctr,aes256-ctr,aes128-gcm@openssh.com,aes256-gcm@openssh.com,chacha20-poly1305@openssh.com,aes128-cbc,3des-cbc,aes192-cbc,aes256-cbc" >> /etc/ssh/sshd_config
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 
 #APACHE


### PR DESCRIPTION
In case if someone has difficulties with ssh login on latest builds.

https://www.linuxminion.com/deprecated-ssh-cryptographic-settings/


fixes next error on mounting or ssh from mac:
/src -o reconnect -o StrictHostKeyChecking=no -o follow_symlinks -o IdentityFile=/Users/shcherby/Projects/docker/env/etc/ssh/magento2docker -o port=2222 -o compression=no
remote host has disconnected