### PR TITLE
Enable php gd and change wget for curl

### DIFF
--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       MYSQL_USER: magento
       MYSQL_PASSWORD: magento
     ports:
-      - "3307:3306"
+      - "3306:3306"
     volumes:
       - "./etc/mysql:/etc/mysql/conf.d"
       - db-volume:/var/lib/mysql

--- a/env/docker-compose.yml
+++ b/env/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       MYSQL_USER: magento
       MYSQL_PASSWORD: magento
     ports:
-      - "3306:3306"
+      - "3307:3306"
     volumes:
       - "./etc/mysql:/etc/mysql/conf.d"
       - db-volume:/var/lib/mysql

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -38,6 +38,7 @@ RUN apt-get update \
 
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
+    && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp\
     && docker-php-ext-configure gd \
     && docker-php-ext-install -j$(nproc) gd bcmath pdo_mysql xsl intl zip \
     && mkdir -p /tmp/libsodium \

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -42,7 +42,7 @@ RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
     && docker-php-ext-install -j$(nproc) gd bcmath pdo_mysql xsl intl zip \
     && mkdir -p /tmp/libsodium \
     && cd /tmp/libsodium \
-    && wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz \
+    && curl https://download.libsodium.org/libsodium/releases/LATEST.tar.gz --output LATEST.tar.gz \
     && tar -xzf LATEST.tar.gz \
     && ./libsodium-stable/configure \
     && make \

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -38,8 +38,7 @@ RUN apt-get update \
 
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
-    && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp\
-    && docker-php-ext-configure gd \
+    && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) gd bcmath pdo_mysql xsl intl zip \
     && mkdir -p /tmp/libsodium \
     && cd /tmp/libsodium \


### PR DESCRIPTION
This merge contains:
- wget was changed by curl to avoid errors with ssl certificates when downloading libsodium source code
- Configuration for php gd
- Redirects mysql port from 3306 on the container to 3307 on the host to avoid conflicts with mysql instalation on host