### PR TITLE
Limit composer to the version 1.x

### DIFF
--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -81,7 +81,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -35,6 +35,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
     && docker-php-ext-configure gd --with-gd --with-webp-dir \
@@ -61,7 +66,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -74,11 +78,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.0/Dockerfile
+++ b/env/etc/php/7.0/Dockerfile
@@ -35,6 +35,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv mcrypt soap sockets \
     && docker-php-ext-configure gd --with-gd --with-webp-dir \
@@ -52,7 +57,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -65,11 +69,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.0/Dockerfile
+++ b/env/etc/php/7.0/Dockerfile
@@ -72,7 +72,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 

--- a/env/etc/php/7.1/Dockerfile
+++ b/env/etc/php/7.1/Dockerfile
@@ -35,6 +35,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv mcrypt soap sockets \
     && docker-php-ext-configure gd --with-gd --with-webp-dir \
@@ -52,7 +57,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -65,11 +69,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.1/Dockerfile
+++ b/env/etc/php/7.1/Dockerfile
@@ -72,7 +72,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 

--- a/env/etc/php/7.2/Dockerfile
+++ b/env/etc/php/7.2/Dockerfile
@@ -36,6 +36,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
     && docker-php-ext-configure gd --with-gd --with-webp-dir \
@@ -62,7 +67,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -75,11 +79,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.2/Dockerfile
+++ b/env/etc/php/7.2/Dockerfile
@@ -82,7 +82,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 

--- a/env/etc/php/7.3/Dockerfile
+++ b/env/etc/php/7.3/Dockerfile
@@ -37,6 +37,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
     && docker-php-ext-configure gd --with-gd --with-webp-dir \
@@ -62,7 +67,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -75,11 +79,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.3/Dockerfile
+++ b/env/etc/php/7.3/Dockerfile
@@ -82,7 +82,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -37,6 +37,11 @@ RUN apt-get update \
     && apt-get update \
     && apt-get clean all
 
+#CREATE USER
+ENV _USER=magento
+ENV _HOME_DIRECTORY=/home/${_USER}
+RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
+
 #PHP EXTENSIONS
 RUN docker-php-ext-install -j$(nproc) iconv soap sockets \
     && docker-php-ext-configure gd --enable-gd --with-freetype --with-jpeg --with-webp \
@@ -60,7 +65,6 @@ COPY ./etc/git/gitconfig ${_HOME_DIRECTORY}/.gitconfig
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
     && apt-get install -y nodejs
 
-
 #BLACKFIRE
 RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -o /tmp/blackfire-probe.tar.gz -D - -L -s https://blackfire.io/api/v1/releases/probe/php/linux/amd64/$version \
@@ -73,11 +77,6 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && curl -A "Docker" -L https://blackfire.io/api/v1/releases/client/linux_static/amd64 | tar zxp -C /tmp/blackfire \
     && mv /tmp/blackfire/blackfire /usr/bin/blackfire \
     && rm -Rf /tmp/blackfire
-
-#CREATE USER
-ENV _USER=magento
-ENV _HOME_DIRECTORY=/home/${_USER}
-RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -80,7 +80,7 @@ ENV _HOME_DIRECTORY=/home/${_USER}
 RUN useradd -m ${_USER} && echo "${_USER}:${_USER}" | chpasswd && chsh ${_USER} -s /bin/bash && adduser ${_USER} sudo
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
     && apt -qy install $PHPIZE_DEPS
 COPY ./etc/composer/auth.json /${_HOME_DIRECTORY}/.composer/auth.json
 


### PR DESCRIPTION
This PR has:
 - Limits the composer version to 1.x to keep Magento compatibility
 - Adjusts the order of user creation
