### PR TITLE
Upgraded mutagen commands to version 0.12

### DIFF
--- a/env/Makefile
+++ b/env/Makefile
@@ -3,7 +3,7 @@ FS_MOUNT_TYPE:=$(shell bash etc/host/config.sh FS_MOUNT_TYPE)
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SRC_DIR:=$(shell bash etc/host/config.sh SOURCE_DIRECTORY)
 
-mutagenSession = $(shell mutagen list | grep 'magento2web')
+mutagenSession = $(shell mutagen sync list | grep 'magento2web')
 
 up:
 	$(info "=====$(shell cat Dockerfile | grep 'FROM')=====")
@@ -37,7 +37,7 @@ php74:
 	$(shell yes | cp etc/php/7.4/Dockerfile .)
 php80:
 	$(info ""=====Buildng container with php 8.0"=====")
-	$(shell yes | cp etc/php/8.0/Dockerfile .)	
+	$(shell yes | cp etc/php/8.0/Dockerfile .)
 logs:
 	docker logs -f magento2web
 logs-db:
@@ -83,7 +83,7 @@ umount-sshfs:
 	umount -f $(SRC_DIR)
 mount-mutagen:
 ifeq ($(mutagenSession),)
-	mutagen create --name=magento2web \
+	mutagen sync create --name=magento2web \
 	--default-group-beta=magento \
 	--default-owner-beta=magento \
 	--sync-mode=two-way-resolved \
@@ -99,10 +99,10 @@ ifeq ($(mutagenSession),)
 	docker://magento@magento2web/var/www/html/
 else
 	@echo "Mutagen magento2web session exits, resuming"
-	mutagen resume magento2web
+	mutagen sync resume magento2web
 endif
 umount-mutagen:
-	mutagen pause magento2web
+	mutagen sync pause magento2web
 mount:
 ifeq "$(FS_MOUNT_TYPE)" "sshfs"
 	make mount-sshfs
@@ -153,7 +153,7 @@ elastic7:
 	# Web interface:
 	# http://127.0.0.1:9207
 elastic7-stop:
-	cd additional/elasticsearch7 && docker-compose stop && cd -	
+	cd additional/elasticsearch7 && docker-compose stop && cd -
 solr:
 	cd additional/solr36 && docker-compose up -d && cd -
 solr-stop:


### PR DESCRIPTION
Mutagen 0.12 was released in October:
https://github.com/mutagen-io/mutagen/releases/tag/v0.12.0
All commands managing the session are available using the command `sync` first.

Run the commands below to upgrade mutagen:
```
brew upgrade mutagen
mutagen daemon stop
mutagen daemon start
```