### PR TITLE
Feature pull request: Added support for Composer 2 for 8.0 and 7.4 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ bin/shell
    - Login to container `make web` 
    - Run `m2install.sh`
 
+## How to link Composer versions
+
+Containers for PHP 7.4 and PHP 8.0 has Composer 2 because of Magento 2.4.2 supports Composer 2 since 2.4.2 
+version.
+
+### Usage:
+- Login to your container `bin/shell-root`
+- To use composer as default you have two commands:
+  - Run command `composer-link.sh 1` to use Composer 1 
+  - Run command `composer-link.sh 2` to use Composer 2 
+
 ## How to Enable xDebug
 
 The container already includes PHP xDebug extension. The xDebug extension is disabled by default because

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -73,8 +73,14 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -Rf /tmp/blackfire
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --1\
     && apt -qy install $PHPIZE_DEPS && mkdir /${_HOME_DIRECTORY}/.composer
+
+#COMPOSER 2 (additional)
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer2 --2
+
+#COMPOSER link (1 is default for PHP 7.4)
+RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer
 
 #XDEBUG
 RUN pecl install xdebug-2.9.0 \
@@ -86,6 +92,7 @@ RUN pecl install xdebug-2.9.0 \
     && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 COPY ./misc/prepare-mtf.sh /usr/local/bin/prepare-mtf.sh
+COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh
 
 #CODESNIFFER
 RUN pear install PHP_CodeSniffer \

--- a/env/Dockerfile
+++ b/env/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update \
     lsof \
     libsodium-dev \
     libzip-dev \
+    parallel \
     && apt-get update \
     && apt-get clean all
 

--- a/env/Makefile
+++ b/env/Makefile
@@ -3,7 +3,7 @@ FS_MOUNT_TYPE:=$(shell bash etc/host/config.sh FS_MOUNT_TYPE)
 ROOT_DIR:=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 SRC_DIR:=$(shell bash etc/host/config.sh SOURCE_DIRECTORY)
 
-mutagenSession = $(shell mutagen list | grep 'magento2web')
+mutagenSession = $(shell mutagen sync list | grep 'magento2web')
 
 up:
 	$(info "=====$(shell cat Dockerfile | grep 'FROM')=====")

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -73,8 +73,15 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -Rf /tmp/blackfire
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --1\
     && apt -qy install $PHPIZE_DEPS && mkdir /${_HOME_DIRECTORY}/.composer
+
+#COMPOSER 2 (additional)
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer2 --2
+
+#COMPOSER link (1 is default for PHP 7.4)
+RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
+    && chmod 777 /usr/local/bin/composer
 
 #XDEBUG
 RUN pecl install xdebug-2.9.0 \
@@ -86,6 +93,7 @@ RUN pecl install xdebug-2.9.0 \
     && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
 COPY ./misc/prepare-mtf.sh /usr/local/bin/prepare-mtf.sh
+COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh
 
 #CODESNIFFER
 RUN pear install PHP_CodeSniffer \

--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -80,8 +80,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer2 --2
 
 #COMPOSER link (1 is default for PHP 7.4)
-RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer \
-    && chmod 777 /usr/local/bin/composer
+RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer
 
 #XDEBUG
 RUN pecl install xdebug-2.9.0 \

--- a/env/etc/php/8.0/Dockerfile
+++ b/env/etc/php/8.0/Dockerfile
@@ -72,8 +72,14 @@ RUN version=$(php -r "echo PHP_MAJOR_VERSION.PHP_MINOR_VERSION;") \
     && rm -Rf /tmp/blackfire
 
 #COMPOSER
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer --1\
-    && apt -qy install $PHPIZE_DEPS && mkdir /${_HOME_DIRECTORY}/.composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --1\
+    && apt -qy install $PHPIZE_DEPS && mkdir /${_HOME_DIRECTORY}/.composer \
+
+#COMPOSER 2 (additional)
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer2 --2
+
+#COMPOSER link (2 is default for PHP 8)
+RUN ln -s /usr/local/bin/composer2 /usr/local/bin/composer
 
 #XDEBUG
 RUN pecl install xdebug-3.0.1 \
@@ -84,6 +90,7 @@ RUN pecl install xdebug-3.0.1 \
     && echo "xdebug.max_nesting_level=10000" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini \
     && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh
+COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh
 
 #CODESNIFFER
 RUN pear install PHP_CodeSniffer \

--- a/env/misc/composer-link.sh
+++ b/env/misc/composer-link.sh
@@ -13,11 +13,11 @@ SCRIPT_NAME=$(basename "${0}");
 composerLinkAction()
 {
   local flag="${1:-0}"
-  local composer="/usr/bin/local/composer${flag}"
-  local composerLink="/usr/bin/local/composer"
+  local composer="/usr/local/bin/composer${flag}"
+  local composerLink="/usr/local/bin/composer"
 
   if [ ! -f "${composer}" ]; then
-	    echo "> ERROR: No {$composer} executable found ..." 1>&2 && return 1
+	    echo "> ERROR: No ${composer} executable found ..." 1>&2 && return 1
   fi
 
   if [ -f "${composerLink}" ]; then
@@ -25,7 +25,7 @@ composerLinkAction()
   fi
 
   ln -s ${composer} ${composerLink}
-  echo "Composer ${composer} was succesfully linked to ${composerLink}!"
+  echo "Composer ${composer} was succesfully linked to ${composerLink}"
 }
 
 

--- a/env/misc/composer-link.sh
+++ b/env/misc/composer-link.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+VERSION=1.0.0
+SCRIPT_NAME=$(basename "${0}");
+
+################################################################################
+# Action Controllers
+################################################################################
+composerLinkAction()
+{
+  local flag="${1:-0}"
+  local composer="/usr/bin/local/composer${flag}"
+  local composerLink="/usr/bin/local/composer"
+
+  if [ ! -f "${composer}" ]; then
+	    echo "> ERROR: No {$composer} executable found ..." 1>&2 && return 1
+  fi
+
+  if [ -f "${composerLink}" ]; then
+  	  unlink ${composerLink}
+  fi
+
+  ln -s ${composer} ${composerLink}
+  echo "Composer ${composer} was succesfully linked to ${composerLink}!"
+}
+
+
+################################################################################
+# Main
+################################################################################
+main()
+{
+  composerLinkAction "$@"
+}
+main "${@:-}"
+


### PR DESCRIPTION
- Added Composer 2 to env/etc/php/7.4/Dockerfile (linked 1 by default)
- Added Composer 2 to env/etc/php/8.0/Dockerfile (linked 2 by default)
- Added linking SH script for switching versions
- Updated documentation
- Minor fixes