### PR TITLE
Error: Composer is not downloaded for 7.4

### DIFF
--- a/env/etc/php/7.4/Dockerfile
+++ b/env/etc/php/7.4/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
 
 #NODEJS
 RUN curl -sL https://deb.nodesource.com/setup_12.x | bash \
-    && apt-get install -y nodejs \
+    && apt-get install -y nodejs
 
 #COMPOSER
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer1 --1\


### PR DESCRIPTION
I faced with an error:

```
 => CACHED [ 6/34] RUN curl -sL https://deb.nodesource.com/setup_12.x | bash     && apt-get install -y n  0.0s
 => CACHED [ 7/34] RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin   0.0s
 => CACHED [ 8/34] RUN ln -s /usr/local/bin/composer1 /usr/local/bin/composer                             0.0s
 => CACHED [ 9/34] RUN pecl install xdebug-2.9.0     && echo ";zend_extension=xdebug.so" >> /usr/local/e  0.0s
 => CACHED [10/34] COPY ./misc/xdebug-php.sh /usr/local/bin/xdebug-php.sh                                 0.0s
 => CACHED [11/34] COPY ./misc/prepare-mtf.sh /usr/local/bin/prepare-mtf.sh                               0.0s
 => CACHED [12/34] COPY ./misc/composer-link.sh /usr/local/bin/composer-link.sh                           0.0s
 => ERROR [13/34] RUN pear install PHP_CodeSniffer     && mkdir /usr/local/magento-ecg-code-sniffer       7.7s
------
 > [13/34] RUN pear install PHP_CodeSniffer     && mkdir /usr/local/magento-ecg-code-sniffer     && cd /usr/local/magento-ecg-code-sniffer/ && composer require magento-ecg/coding-standard     && phpcs --config-set installed_paths /usr/local/magento-ecg-code-sniffer/vendor/magento-ecg/coding-standard:
#17 6.509 downloading PHP_CodeSniffer-3.6.2.tgz ...
#17 6.511 Starting to download PHP_CodeSniffer-3.6.2.tgz (774,203 bytes)
#17 6.637 ..........................................................................................................................................................done: 774,203 bytes
#17 7.641 install ok: channel://pear.php.net/PHP_CodeSniffer-3.6.2
#17 7.681 /bin/sh: 1: composer: not found
------
executor failed running [/bin/sh -c pear install PHP_CodeSniffer     && mkdir /usr/local/magento-ecg-code-sniffer     && cd /usr/local/magento-ecg-code-sniffer/ && composer require magento-ecg/coding-standard     && phpcs --config-set installed_paths /usr/local/magento-ecg-code-sniffer/vendor/magento-ecg/coding-standard]: exit code: 127
ERROR: Service 'web' failed to build : Build failed
make: *** [build] Error 1
```

After minutes of debugging understand the reason.