### PR TITLE
RC 3.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ With Magento2Docker v3 it is super easy to start or stop containers:
 ./bin.m2d show M2D_SEARCH_ENGINE_VENDOR
 
 # To start containers after enabling or disabling services or editing parameters:
-./bin/m2d up --buld
+./bin/m2d up --build
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,19 @@ You can download archive of this project on [Release Page](https://github.com/yv
 - Mailcatcher: latest
 - Selenium: 3.14.0
 
+### Domains
+With the default setup, Magento2Docker will use nip.io in this way:
+`http://{LEVEL_2}.{LEVEL_1}.127.0.0.1.nip.io`
+where:
+- LEVEL_1 is a name of a folder inside /var/www/html
+- LEVEL_2 is a subdomain that can be used to simulate multi-website Magento setup
+
+Assume you have a multi-website Magento setup in the m246 folder; your domains can look like this:
+- http://m246.127.0.0.1.nip.io
+- http://website1.m246.127.0.0.1.nip.io
+- http://website2.m246.127.0.0.1.nip.io
+All the above will point to /var/www/html/m246 in your container.
+
 
 ## Usage
 To work with Magento2Docker you can use `m2d` CLI command located in `bin` of Magento2Docker project.

--- a/bin/m2d
+++ b/bin/m2d
@@ -73,6 +73,8 @@ Options:
   -h, --help Display help for command
 
 Parameters:
+  home     Display path to the directory where Magento2Docker is installed
+  src      Display path to the source directory [M2D_SOURCE_DIRECTORY]
   [M2D_*]  Parameter name. A list of possible parameters is in the '.env.example' file
 "
 }
@@ -471,6 +473,12 @@ case $1 in
         case $2 in
             '-h'|'--help')
                 _m2d_display_help_show
+                ;;
+            'home')
+                echo "$M2D_PROJECT_PATH"
+                ;;
+            'src')
+                _m2d_env_get_parameter "$M2D_ENV_FILE" M2D_SOURCE_DIRECTORY
                 ;;
             *)
                 _m2d_env_get_parameter "$M2D_ENV_FILE" "$2"

--- a/services/web-servers/apache/Dockerfile
+++ b/services/web-servers/apache/Dockerfile
@@ -41,6 +41,7 @@ RUN apt-get update \
         parallel \
         git \
         mc \
+        rsync \
     && apt-get update \
     && apt-get clean all
 

--- a/services/web-servers/apache/Dockerfile
+++ b/services/web-servers/apache/Dockerfile
@@ -114,12 +114,6 @@ RUN curl -o /usr/local/bin/m2install.sh https://raw.githubusercontent.com/yvoron
     && tar -xf /tmp/teleport.tar.gz -C /tmp/ \
     && make -C /tmp/teleport/
 
-# ADOBE TOOLS:
-RUN git ls-remote git@github.com:magento-sparta/ee-support-tools.git 2>&1 | if grep -q HEAD; then git clone git@github.com:magento-sparta/ee-support-tools.git /usr/local/src/ee-support-tools; else echo; fi \
-    && if [ -d /usr/local/src/ee-support-tools ]; then ln -s /usr/local/src/ee-support-tools/cloud-teleport/cloud-teleport /usr/local/bin/cloud-teleport; else echo; fi
-RUN git ls-remote git@github.com:magento-sparta/m-it.git 2>&1 | if grep -q HEAD; then git clone git@github.com:magento-sparta/m-it.git /usr/local/src/m-it; else echo; fi \
-    && if [ -d /usr/local/src/m-it ]; then /usr/local/src/m-it/mit-installer.sh; else echo; fi
-
 # USER CONTEXT CONFIGURATION
 USER magento
 
@@ -136,10 +130,6 @@ RUN echo "source /etc/bash_completion" >> ${_HOME_DIRECTORY}/.bashrc
 
 # MAGENTO CLI:
 RUN curl -sS https://accounts.magento.cloud/cli/installer | php
-
-# ADOBE TOOLS:
-RUN if [ -d /usr/local/src/m-it ]; then /usr/local/src/m-it/mit-installer.sh; else echo; fi
-RUN sed -i.back '/^export BASH_IT_THEME=/ s/^/# /' ${_HOME_DIRECTORY}/.bashrc
 
 USER root
 RUN chown -R "${_USER}:${_USER}" ${_HOME_DIRECTORY}/.gitconfig ${_HOME_DIRECTORY}/.composer ${_HOME_DIRECTORY}/.m2install.conf*; \

--- a/services/web-servers/apache/etc/apache2/sites-enabled/second-level.nip.io.conf
+++ b/services/web-servers/apache/etc/apache2/sites-enabled/second-level.nip.io.conf
@@ -2,7 +2,7 @@ UseCanonicalName Off
 <VirtualHost *:80>
 	ServerAdmin webmaster@localhost
     ServerAlias *.*.127.0.0.1.nip.io
-    VirtualDocumentRoot /var/www/html/%1/%2
+    VirtualDocumentRoot /var/www/html/%2
         <Directory //>
             Options -Indexes +FollowSymLinks +MultiViews
             AllowOverride All


### PR DESCRIPTION
- Fixed multi-website default configuration for Apache + added README section about used domains;
- Added `m2d show home` and `m2d show src` to display path to Magento2Docker setup and source folders;
- Added rsync to web container;
- Removed Adobe internal tools;
- Fixed mistyped command in README.md;