### PR TITLE
Bug Fix: Multiple instance in folders with the same name

### DIFF
--- a/bin/m2d
+++ b/bin/m2d
@@ -386,7 +386,7 @@ function _m2d_sync ()
             local sync_web="m2d-web$(_m2d_env_get_parameter $env_file M2D_PROJECT_SUFFIX)"
             case $action in
                 'start')
-                    if [[ -n $(mutagen sync list | grep $sync_name) ]]; then
+                    if [[ -n $(mutagen sync list | grep "^Name: $sync_name$") ]]; then
                         mutagen sync resume $sync_name
                     else
                         mutagen sync create --name=$sync_name \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 version: '3'
 
+name: "m2d${M2D_PROJECT_SUFFIX:-}"
 services:
   web:
     container_name: "m2d-web${M2D_PROJECT_SUFFIX:-}"


### PR DESCRIPTION
- Fixed issue when multiple instances are deployed in folders with the same names, e.g., ~/project1/m2d and ~/project2/m2d
- Fixed issue with mutagen session selection when session names are like m2d and m2d-project1